### PR TITLE
added redirected.html

### DIFF
--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -1,0 +1,14 @@
+<!--from https://superdevresources.com/redirects-jekyll-github-pages/-->
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>

--- a/clowder.md
+++ b/clowder.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: /clowder
+redirect_to:  https://terraref.ncsa.illinois.edu/clowder/
+---


### PR DESCRIPTION
Following https://superdevresources.com/redirects-jekyll-github-pages/ to support redirects from terraref.org to terraref.ncsa.illinois.edu
